### PR TITLE
Configuration Change Proposal

### DIFF
--- a/scripts/config.lua
+++ b/scripts/config.lua
@@ -4,6 +4,10 @@
 
 redis_host="127.0.0.1"
 redis_port=6379
+notice_key="EVE:notice"
+log_dir="/var/log/mobster"
+log_file="mobster.log"
+script_dir="/opt/mobster/scripts"
 
 mobster_scripts= 
 {

--- a/scripts/dns-events.lua
+++ b/scripts/dns-events.lua
@@ -2,9 +2,8 @@
 --
 -- ----------------------------------------------
 
-local mobster_root = os.getenv("MOBSTER_ROOT")
-package.path = mobster_root.."/scripts/?.lua;" .. package.path
-package.cpath = mobster_root.."/lib/?.so;" .. package.cpath
+package.path = script_dir.."/?.lua;" .. package.path
+package.cpath = script_dir.."/lib/?.so;" .. package.cpath
 
 local redis = require('redis')
 local json = require('cjson')

--- a/scripts/file-events.lua
+++ b/scripts/file-events.lua
@@ -2,9 +2,8 @@
 --
 -- ----------------------------------------------
 
-local mobster_root = os.getenv("MOBSTER_ROOT")
-package.path = mobster_root.."/scripts/?.lua;" .. package.path
-package.cpath = mobster_root.."/lib/?.so;" .. package.cpath
+package.path = script_dir.."/?.lua;" .. package.path
+package.cpath = script_dir.."/lib/?.so;" .. package.cpath
 
 local redis = require('redis')
 local json = require('cjson')

--- a/scripts/flow-events.lua
+++ b/scripts/flow-events.lua
@@ -2,9 +2,8 @@
 --
 -- ----------------------------------------------
 
-local mobster_root = os.getenv("MOBSTER_ROOT")
-package.path = mobster_root.."/scripts/?.lua;" .. package.path
-package.cpath = mobster_root.."/lib/?.so;" .. package.cpath
+package.path = script_dir.."/?.lua;" .. package.path
+package.cpath = script_dir.."/lib/?.so;" .. package.cpath
 
 local redis = require('redis')
 local json = require('cjson')

--- a/scripts/http-events.lua
+++ b/scripts/http-events.lua
@@ -2,9 +2,8 @@
 --
 -- ----------------------------------------------
 
-local mobster_root = os.getenv("MOBSTER_ROOT")
-package.path = mobster_root.."/scripts/?.lua;" .. package.path
-package.cpath = mobster_root.."/lib/?.so;" .. package.cpath
+package.path = script_dir.."/?.lua;" .. package.path
+package.cpath = script_dir.."/lib/?.so;" .. package.cpath
 
 local redis = require('redis')
 local json = require('cjson')

--- a/scripts/notice-events.lua
+++ b/scripts/notice-events.lua
@@ -3,8 +3,8 @@
 -- ----------------------------------------------
 
 local mobster_root = os.getenv("MOBSTER_ROOT")
-package.path = mobster_root.."/scripts/?.lua;" .. package.path
-package.cpath = mobster_root.."/lib/?.so;" .. package.cpath
+package.path = script_dir.."/?.lua;" .. package.path
+package.cpath = script_dir.."/lib/?.so;" .. package.cpath
 
 local redis = require('redis')
 local json = require('cjson')

--- a/scripts/notice-events.lua
+++ b/scripts/notice-events.lua
@@ -8,24 +8,26 @@ package.cpath = script_dir.."/lib/?.so;" .. package.cpath
 
 local redis = require('redis')
 local json = require('cjson')
-local notice_log_path = "/var/log/notice.log"
+local notice_log_path = log_dir.."/notice.log"
 
 -- ----------------------------------------------
 --
 -- ----------------------------------------------
 function process()
-	local channels = { 'EVE:notice' }
+        print(notice_log_path)
+	local channels = { notice_key }
 	local params = { host = redis_host, port = redis_port }
 
 	local listen = redis.connect(params)
 	local client = redis.connect(params)
-	local notice_log = io.open(notice_log_path, "a")
+	local notice_log = io.open(notice_log_path, "a+")
 
 	for msg, abort in listen:pubsub({ subscribe = channels }) do
 	    if msg.kind == 'subscribe' then
                 print('subscribed to channel '..msg.channel)
             elseif msg.kind == 'message' then
 		notice_log:write(msg.payload,"\n")
+                notice_log:flush()
 	    end
 	end
 

--- a/scripts/notice-events.lua
+++ b/scripts/notice-events.lua
@@ -14,7 +14,6 @@ local notice_log_path = log_dir.."/notice.log"
 --
 -- ----------------------------------------------
 function process()
-        print(notice_log_path)
 	local channels = { notice_key }
 	local params = { host = redis_host, port = redis_port }
 

--- a/scripts/notice-events.lua
+++ b/scripts/notice-events.lua
@@ -2,7 +2,6 @@
 --
 -- ----------------------------------------------
 
-local mobster_root = os.getenv("MOBSTER_ROOT")
 package.path = script_dir.."/?.lua;" .. package.path
 package.cpath = script_dir.."/lib/?.so;" .. package.cpath
 

--- a/scripts/ssh-events.lua
+++ b/scripts/ssh-events.lua
@@ -2,9 +2,8 @@
 --
 -- ----------------------------------------------
 
-local mobster_root = os.getenv("MOBSTER_ROOT")
-package.path = mobster_root.."/scripts/?.lua;" .. package.path
-package.cpath = mobster_root.."/lib/?.so;" .. package.cpath
+package.path = script_dir.."/?.lua;" .. package.path
+package.cpath = script_dir.."/lib/?.so;" .. package.cpath
 
 local redis = require('redis')
 local json = require('cjson')

--- a/scripts/sumstats-events.lua
+++ b/scripts/sumstats-events.lua
@@ -3,9 +3,8 @@
 -- ----------------------------------------------
 
 
-local mobster_root = os.getenv("MOBSTER_ROOT")
-package.path = mobster_root.."/scripts/?.lua;" .. package.path
-package.cpath = mobster_root.."/lib/?.so;" .. package.cpath
+package.path = script_dir.."/?.lua;" .. package.path
+package.cpath = script_dir.."/lib/?.so;" .. package.cpath
 
 local redis = require('redis')
 local json = require('cjson')

--- a/scripts/tls-events.lua
+++ b/scripts/tls-events.lua
@@ -2,9 +2,8 @@
 --
 -- ----------------------------------------------
 
-local mobster_root = os.getenv("MOBSTER_ROOT")
-package.path = mobster_root.."/scripts/?.lua;" .. package.path
-package.cpath = mobster_root.."/lib/?.so;" .. package.cpath
+package.path = script_dir.."/?.lua;" .. package.path
+package.cpath = script_dir.."/lib/?.so;" .. package.cpath
 
 local redis = require('redis')
 local json = require('cjson')

--- a/src/event_handlers.c
+++ b/src/event_handlers.c
@@ -307,7 +307,7 @@ static void run_mobster (const char* mobster_config)
 
        snprintf (temp_script_dir, PATH_MAX, "%s/%s", mobster_root, "/scripts");
 
-       if (!temp_script_dir)
+       if (!temp_script_dir || !mobser_root)
        {
           fprintf (stderr,"Script Directory %s does not exist and cannot location under mobster_root\n", script_dir);
           exit (EXIT_FAILURE);

--- a/src/event_handlers.c
+++ b/src/event_handlers.c
@@ -222,6 +222,9 @@ static void *lua_thread (void *ptr)
     syslog (LOG_INFO, "Loading %s", lua_script);
     lua_pushstring(L, script_dir);
     lua_setglobal(L, "script_dir");
+    lua_pushstring(L, log_dir);
+    lua_setglobal(L, "log_dir");
+
     if (luaL_loadfile(L, lua_script)||lua_pcall(L, 0, 0, 0))
     {
         syslog (LOG_ERR, "luaL_loadfile %s failed - %s",lua_script, lua_tostring(L, -1));
@@ -235,6 +238,8 @@ static void *lua_thread (void *ptr)
     lua_setglobal(L, "redis_host");
     lua_pushcfunction(L, mobster_notify);
     lua_setglobal(L, "mobster_notify");
+    lua_pushstring(L, notice_key);
+    lua_setglobal(L, "notice_key");
 
 
     syslog (LOG_NOTICE,"Running %s as %s\n", lua_script, name);
@@ -307,7 +312,7 @@ static void run_mobster (const char* mobster_config)
 
        snprintf (temp_script_dir, PATH_MAX, "%s/%s", mobster_root, "/scripts");
 
-       if (!temp_script_dir || !mobser_root)
+       if (!temp_script_dir || !mobster_root)
        {
           fprintf (stderr,"Script Directory %s does not exist and cannot location under mobster_root\n", script_dir);
           exit (EXIT_FAILURE);

--- a/src/event_handlers.h
+++ b/src/event_handlers.h
@@ -24,7 +24,7 @@
 #ifndef _MOBSTER_THREAD_
 #define _MOBSTER_THREAD_
 
-int mobster_start(const char *mobster_root);
+int mobster_start(const char *mobster_config);
 
 #endif
 

--- a/src/mobster.c
+++ b/src/mobster.c
@@ -66,15 +66,22 @@ int main(int argc, char **argv)
            if ((lstat (argv[1],&sb)<0) || !S_ISREG(sb.st_mode))
            {
 	      mobster_root=getenv(MOBSTER_ROOT);
+              char config_file [PATH_MAX];
+              snprintf (config_file, PATH_MAX, "%s/%s", mobster_root, "/scripts/config.lua");
+
               if (!mobster_root)
               {
                  fprintf (stderr,"Config file %s and environment variable MOBSTER_ROOT do not exist\n", argv[1]);
                  exit (EXIT_FAILURE);
               }
+              else if ((lstat (config_file,&sb)<0) || !S_ISREG(sb.st_mode))
+              {
+                 fprintf (stderr,"Config file specified does not exist. $MOBSTER_ROOT/scripts/config.lua does not exist\n");
+                 exit (EXIT_FAILURE);
+              }
               else
               {
-                 fprintf (stderr,"Config file specified does not exist.  Using MOBSTER_ROOT\n");
-                 mobster_config=strcpy(mobster_root,"/config.lua");
+                 mobster_config=config_file;
               }
            }
            else
@@ -96,7 +103,14 @@ int main(int argc, char **argv)
 	      fprintf (stderr,"MOBSTER_ROOT %s does not exist\n", mobster_root);
 	      exit (EXIT_FAILURE);
 	   }
-           mobster_config=strcpy(mobster_root,"/config.lua");
+           char config_file [PATH_MAX];
+           snprintf (config_file, PATH_MAX, "%s/%s", mobster_root, "/scripts/config.lua");
+           if ((lstat (config_file,&sb)<0) || !S_ISREG(sb.st_mode))
+           {
+              fprintf (stderr,"$MOBSTER_ROOT/scripts/config.lua does not exist\n.");
+              exit (EXIT_FAILURE);
+           }
+           mobster_config=config_file;
         }
         int path_len = strlen(mobster_config);
         if (path_len > PATH_MAX)

--- a/src/mobster.c
+++ b/src/mobster.c
@@ -53,25 +53,64 @@ uint64_t g_running = 1;
 int main(int argc, char **argv)
 {
 	struct stat sb;
-	const char* mobster_root=getenv(MOBSTER_ROOT);
 
-	if (!mobster_root)
+        char* mobster_root;
+        char* mobster_config;
+        if ( argc > 2 ) /* Check to see if too many arguments were presented */
+        {
+           fprintf (stderr, "Too many arguments supplied\n");
+           exit (EXIT_FAILURE);
+        }
+        else if ( argc == 2) /* Second Option is location of config file */
+        {
+           if ((lstat (argv[1],&sb)<0) || !S_ISREG(sb.st_mode))
+           {
+	      mobster_root=getenv(MOBSTER_ROOT);
+              if (!mobster_root)
+              {
+                 fprintf (stderr,"Config file %s and environment variable MOBSTER_ROOT do not exist\n", argv[1]);
+                 exit (EXIT_FAILURE);
+              }
+              else
+              {
+                 fprintf (stderr,"Config file specified does not exist.  Using MOBSTER_ROOT\n");
+                 mobster_config=strcpy(mobster_root,"/config.lua");
+              }
+           }
+           else
+           {
+              mobster_config=argv[1];
+           }
+        }
+        else /* Otherwise look for mobster_root */
 	{
-	   fprintf (stderr,"Must define environment variable MOBSTER_ROOT\n");
-	   exit (EXIT_FAILURE);
-	}
- 	if ((lstat (mobster_root,&sb)<0) || !S_ISDIR(sb.st_mode))
-	{
-	   fprintf (stderr,"MOBSTER_ROOT %s does not exist\n", mobster_root);
-	   exit (EXIT_FAILURE);
-	}
+           mobster_root=getenv(MOBSTER_ROOT);
+
+	   if (!mobster_root)
+	   {
+	      fprintf (stderr,"Must define environment variable MOBSTER_ROOT\n");
+	      exit (EXIT_FAILURE);
+	   }
+ 	   if ((lstat (mobster_root,&sb)<0) || !S_ISDIR(sb.st_mode))
+	   {
+	      fprintf (stderr,"MOBSTER_ROOT %s does not exist\n", mobster_root);
+	      exit (EXIT_FAILURE);
+	   }
+           mobster_config=strcpy(mobster_root,"/config.lua");
+        }
+        int path_len = strlen(mobster_config);
+        if (path_len > PATH_MAX)
+        {
+           fprintf (stderr,"Pathname of config file is too large (%i characters)", path_len);
+           exit (EXIT_FAILURE);
+        }
 
 	signal(SIGPIPE, SIG_IGN);
 	openlog ("mobster", LOG_PERROR, LOG_USER);
 
         pthread_setname_np(pthread_self(), "mobster");
 
-	if (mobster_start (mobster_root) < 0)
+	if (mobster_start (mobster_config) < 0)
 	{
 		syslog (LOG_ERR,"mobster_start() failed");
 		return (EXIT_FAILURE);


### PR DESCRIPTION
I've been looking forward to trying out this project since I saw the conference slides back in November and have been quite impressed with the efficiency of it thus far.  The one piece I found difficult was not being able to customize enough.  Specifically being able to tell the notice logs apart with multiple instances running or running different scripts per instance.   The changes I submitted in this request was to allow a few additional options to be accepted through the config and to be able to specify a config file instead of going by $MOBSTER_ROOT; although $MOBSTER_ROOT still remains as an option.

Syntax of specifying the config is simply mobster *full_path_to_config_file*

Below are the options I've added to config.lua.  notice_key, log_dir and log_file are the defaults that will remain if no item is specified.  script_dir will fall back to $MOBSTER_ROOT if not present or specified location doesn't exist.
- notice_key="EVE:notice"
- log_dir="/var/log/mobster"
- log_file="mobster.log"
- script_dir="/opt/mobster/scripts"

I also presented script_dir, log_dir and notice_key to the lua scripts and modified accordingly.  

I did run into issues with lua 5.2 (vs 5.1) and the include statements for lua.h, luaxlib.h and lualib.h so that may be something that needs to be adjusted to work with raspbian.  I've tested this version on Fedora 21, CentOS 7.1 and Ubuntu 14.04.