### PR TITLE
travis-ci: initial support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: c
+compiler:
+  - gcc
+  - clang
+# Change this to your needs
+script: sh autogen.sh && ./configure --enable-lua && make && make check
+addons:
+  apt:
+    packages:
+    - build-essential
+    - autoconf
+    - automake
+    - libtool
+    - liblua5.1-0-dev
+    - libhiredis-dev
+    - libevent-dev
+    - make
+before_install:
+sudo: false


### PR DESCRIPTION
Initial travis-CI integration. Output looks like this: https://travis-ci.org/inliniac/mobster/builds/100161801

You'll have to enable this on travis-CI for your account, see https://docs.travis-ci.com/user/getting-started/